### PR TITLE
Added support for reading pretrained graph definition files 

### DIFF
--- a/c_src/Tensorflex.c
+++ b/c_src/Tensorflex.c
@@ -2,14 +2,53 @@
 #include "c_api.h"
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 
-ErlNifResourceType *graph_resource, *op_desc_resource;
+void free_buffer(void* data, size_t length) {
+  free(data);
+}
+
+
+
+ErlNifResourceType *graph_resource, *op_desc_resource, *tensor_resource, *session_resource, *op_resource, *buffer_resource, *status_resource, *graph_opts_resource;
 
 void graph_destr(ErlNifEnv *env, void *res) {
   TF_DeleteGraph(*(TF_Graph **)res);
 }
 
+void graph_opts_destr(ErlNifEnv *env, void *res) {
+  TF_DeleteImportGraphDefOptions(*(TF_ImportGraphDefOptions **)res);
+}
+
+void tensor_destr(ErlNifEnv *env, void *res) {
+  TF_DeleteTensor(*(TF_Tensor **)res);
+}
+
+void status_destr(ErlNifEnv *env, void *res) {
+  TF_DeleteStatus(*(TF_Status**)res);
+}
+
+void buffer_destr(ErlNifEnv *env, void *res) {
+  TF_DeleteBuffer(*(TF_Buffer **)res);
+}
+
+void session_destr(ErlNifEnv *env, void *res) {
+  TF_Status *status = TF_NewStatus();
+  TF_DeleteSession(*(TF_Session **)res, status);
+  if (TF_GetCode(status) != TF_OK) {
+    fprintf(stderr, "Error: Cannot delete session!: %s\r\n", TF_Message(status));
+  }
+  TF_DeleteStatus(status);
+}
+
+void op_destr(ErlNifEnv *env, void *res) {}
+
 void op_desc_destr(ErlNifEnv *env, void *res) {}
+
+void tensor_deallocator(void* data, size_t len, void* arg) {
+  fprintf(stderr, "free tensor %p\r\n", data);
+  enif_free(data);
+}
 
 static ERL_NIF_TERM version(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
@@ -20,6 +59,12 @@ int res_loader(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM load_info) {
   int flags = ERL_NIF_RT_CREATE | ERL_NIF_RT_TAKEOVER;
   graph_resource = enif_open_resource_type(env, NULL, "graph", graph_destr, flags, NULL);
   op_desc_resource = enif_open_resource_type(env, NULL, "op_desc", op_desc_destr, flags, NULL);
+  op_resource = enif_open_resource_type(env, NULL, "op", op_destr, flags, NULL);
+  status_resource = enif_open_resource_type(env, NULL, "status", status_destr, flags, NULL);
+  tensor_resource = enif_open_resource_type(env, NULL, "tensor", tensor_destr, flags, NULL);
+  session_resource = enif_open_resource_type(env, NULL, "session", session_destr, flags, NULL);
+  buffer_resource = enif_open_resource_type(env, NULL, "buffer", buffer_destr, flags, NULL);
+  graph_opts_resource = enif_open_resource_type(env, NULL, "graph_opts",graph_opts_destr, flags, NULL);
   return 0;
 }
 
@@ -28,6 +73,48 @@ static ERL_NIF_TERM string_constant(ErlNifEnv *env, int argc, const ERL_NIF_TERM
   char buf[1024];
   enif_get_string(env, argv[0] , buf, 1024, ERL_NIF_LATIN1);
   return enif_make_string(env, buf, ERL_NIF_LATIN1);
+}
+
+static ERL_NIF_TERM read_file(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+  ErlNifBinary filepath;
+  enif_inspect_binary(env,argv[0], &filepath);
+
+  char* file = enif_alloc(filepath.size+1);
+  memset(file, 0, filepath.size+1);
+  memcpy(file, (void *) filepath.data, filepath.size);
+
+  FILE *f = fopen(file, "rb");
+  fseek(f, 0, SEEK_END);
+  long fsize = ftell(f);
+  fseek(f, 0, SEEK_SET);
+
+  void* data = malloc(fsize);
+  fread(data, fsize, 1, f);
+  fclose(f);
+
+  TF_Buffer* buf = TF_NewBuffer();
+  buf->data = data;
+  buf->length = fsize;
+  buf->data_deallocator = free_buffer;
+
+  TF_Buffer **buffer_resource_alloc = enif_alloc_resource(buffer_resource, sizeof(TF_Buffer *));
+  memcpy((void *) buffer_resource_alloc, (void *) &buf, sizeof(TF_Buffer *));
+  ERL_NIF_TERM buffer = enif_make_resource(env, buffer_resource_alloc);
+  enif_release_resource(buffer_resource_alloc);
+  return buffer;
+
+}
+
+
+static ERL_NIF_TERM new_import_graph_def_opts(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+  TF_ImportGraphDefOptions **graph_opts_resource_alloc = enif_alloc_resource(graph_opts_resource, sizeof(TF_ImportGraphDefOptions *));
+  TF_ImportGraphDefOptions *new_graph_opts = TF_NewImportGraphDefOptions();
+  memcpy((void *) graph_opts_resource_alloc, (void *) &new_graph_opts, sizeof(TF_ImportGraphDefOptions *));
+  ERL_NIF_TERM graph_opts = enif_make_resource(env, graph_opts_resource_alloc);
+  enif_release_resource(graph_opts_resource_alloc);
+  return graph_opts;
 }
 
 static ERL_NIF_TERM new_graph(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
@@ -39,7 +126,6 @@ static ERL_NIF_TERM new_graph(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
   enif_release_resource(graph_resource_alloc);
   return graph;
 }
-
 
 static ERL_NIF_TERM new_op(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
@@ -62,6 +148,31 @@ static ERL_NIF_TERM new_op(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
   ERL_NIF_TERM op_desc = enif_make_resource(env, op_desc_resource_alloc);
   enif_release_resource(op_desc_resource_alloc);
   return op_desc;
+}
+
+static ERL_NIF_TERM graph_import_graph_def(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+  TF_Graph **graph;
+  enif_get_resource(env, argv[0], graph_resource, (void *) &graph);
+
+  TF_Buffer **buffer;
+  enif_get_resource(env, argv[1], buffer_resource, (void *) &buffer);
+
+  TF_ImportGraphDefOptions **graph_opts;
+  enif_get_resource(env, argv[2], graph_opts_resource, (void *) &graph_opts);
+
+  TF_Status* status = TF_NewStatus();
+  
+  TF_GraphImportGraphDef(*graph, *buffer, *graph_opts, status);
+  if (TF_GetCode(status) != TF_OK) {
+    fprintf(stderr, "ERROR: Unable to import graph %s", TF_Message(status));
+    return 1;
+  }
+  else {
+    fprintf(stderr, "Successfully imported graph\n");
+  }
+
+  return enif_make_string(env, "[INFO] Graph loaded\n", ERL_NIF_LATIN1);
 }
 
 static ERL_NIF_TERM create_and_run_sess(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
@@ -109,8 +220,11 @@ static ERL_NIF_TERM create_and_run_sess(ErlNifEnv *env, int argc, const ERL_NIF_
 static ErlNifFunc nif_funcs[] =
   {
     { "version", 0, version },
+    { "read_file", 1, read_file },
     { "new_graph", 0, new_graph },
+    { "new_import_graph_def_opts", 0, new_import_graph_def_opts },
     { "new_op", 3, new_op },
+    { "graph_import_graph_def", 3, graph_import_graph_def },
     { "string_constant", 1, string_constant },
     { "create_and_run_sess", 3, create_and_run_sess }
   };

--- a/lib/tensorflex.ex
+++ b/lib/tensorflex.ex
@@ -17,8 +17,20 @@ defmodule Tensorflex do
     raise "NIF tf_new_op/3 not implemented"
   end
 
+  def new_import_graph_def_opts do
+    raise "NIF tf_new_import_graph_def_opts/0 not implemented"
+  end
+
+  def graph_import_graph_def(_graph, _graph_def, _graph_opts) do
+    raise "NIF graph_import_graph_def/3 not implemented"
+  end
+
   def string_constant(_value) do
     raise "NIF tf_string_constant/1 not implemented"
+  end
+
+  def read_file(_file) do
+    raise "NIF read_file/1 not implemented"
   end
 
   def create_and_run_sess(_graph, _opdesc, _tensor) do


### PR DESCRIPTION
This PR adds support for reading a pretrained Graph into Tensorflex. This has been made possibly with the porting and addition of three important functions (Creating a new empty graph is also required but that was already added long back as `Tensorflex.new_graph`):

- `Tensorflex.new_import_graph_def_opts`: This is a wrapper around the Tensorflow function `TF_NewImportGraphDefOptions()` and is needed when a pretrained graph is required to be read in to Tensorflow/Tensorflex
- `Tensorflex.read_file('path_to_graphdef_file')`: This function is not actually present directly in Tensorflow but is written to allow reading in the pretrained graph definition protobuf file as a Tensorflow `TF_Buffer` datatype
- `Tensorflex.graph_import_graph_def(graph, graph_def, graph_opts)`: This function takes in a new empty graph, the graph_def obtained using `read_file` and the graph_opts which were obtained using the first function mentioned here

For clarity an example has also been added to the README which reads in the Inception graph definition created by Google.