### PR TITLE
Merged all support functions into read_graph; returning atoms

### DIFF
--- a/lib/tensorflex.ex
+++ b/lib/tensorflex.ex
@@ -17,20 +17,12 @@ defmodule Tensorflex do
     raise "NIF tf_new_op/3 not implemented"
   end
 
-  def new_import_graph_def_opts do
-    raise "NIF tf_new_import_graph_def_opts/0 not implemented"
-  end
-
-  def graph_import_graph_def(_graph, _graph_def, _graph_opts) do
-    raise "NIF graph_import_graph_def/3 not implemented"
+  def read_graph(_filepath) do
+    raise "NIF read_graph/1 not implemented"
   end
 
   def string_constant(_value) do
     raise "NIF tf_string_constant/1 not implemented"
-  end
-
-  def read_file(_file) do
-    raise "NIF read_file/1 not implemented"
   end
 
   def create_and_run_sess(_graph, _opdesc, _tensor) do


### PR DESCRIPTION
@josevalim as discussed in #3 , merged all graph reading capabilities into the `read_graph` function. This function returns a `TF_Graph` on successful loading of graph and an `{:error,"Unable to load graph"}` tuple on an unsuccessful attempt.

Example is as follows (`classify_image_graph_def.pb` is from Google's Imagenet model):

```elixir
iex(1)> graph = Tensorflex.read_graph("classify_image_graph_def.pb")
2018-05-17 23:36:16.488469: I tensorflow/core/platform/cpu_feature_guard.cc:137] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA 2018-05-17 23:36:16.774442: W tensorflow/core/framework/op_def_util.cc:334] OpBatchNormWithGlobalNormalization is deprecated. It will cease to work in GraphDef version 9. Use tf.nn.batch_normalization().
Successfully imported graph
#Reference<0.1610607974.1988231169.250293>

iex(2)> graph2 = Tensorflex.read_graph("Makefile")                   
{:error, 'Unable to import graph'}

```
I have an idea for the "story" around the graph loading we had talked about, so I'll be merging this PR as already discussed and adding the details of that in the next PR for your review.
