### PR TITLE
Added function to print all operations present in graph

### DIFF
--- a/c_src/Tensorflex.c
+++ b/c_src/Tensorflex.c
@@ -162,6 +162,21 @@ static ERL_NIF_TERM read_graph(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv
   
 }
 
+static ERL_NIF_TERM print_graph_ops(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+  TF_Graph **graph;
+  enif_get_resource(env, argv[0], graph_resource, (void *) &graph);
+
+  size_t pos = 0;
+  TF_Operation* op;
+  while ((op = TF_GraphNextOperation(*graph, &pos)) != NULL) {
+    fprintf(stderr, "%s\n",TF_OperationName(op));	
+  }
+
+  return enif_make_atom(env,"ok");
+  
+}
+
 static ERL_NIF_TERM create_and_run_sess(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
   TF_Graph **graph;
@@ -210,6 +225,7 @@ static ErlNifFunc nif_funcs[] =
     { "new_graph", 0, new_graph },
     { "new_op", 3, new_op },
     { "read_graph", 1, read_graph },
+    { "print_graph_ops", 1, print_graph_ops },
     { "string_constant", 1, string_constant },
     { "create_and_run_sess", 3, create_and_run_sess }
   };

--- a/c_src/Tensorflex.c
+++ b/c_src/Tensorflex.c
@@ -4,11 +4,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define BASE_STRING_LENGTH 255
+
 void free_buffer(void* data, size_t length) {
   free(data);
 }
-
-
 
 ErlNifResourceType *graph_resource, *op_desc_resource, *tensor_resource, *session_resource, *op_resource, *buffer_resource, *status_resource, *graph_opts_resource;
 
@@ -75,7 +75,6 @@ static ERL_NIF_TERM string_constant(ErlNifEnv *env, int argc, const ERL_NIF_TERM
   return enif_make_string(env, buf, ERL_NIF_LATIN1);
 }
 
-
 static ERL_NIF_TERM new_import_graph_def_opts(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
   TF_ImportGraphDefOptions **graph_opts_resource_alloc = enif_alloc_resource(graph_opts_resource, sizeof(TF_ImportGraphDefOptions *));
@@ -119,6 +118,48 @@ static ERL_NIF_TERM new_op(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
   return op_desc;
 }
 
+const char* error_to_string(TF_Status* status, char* error)
+{
+  switch(TF_GetCode(status))
+    {
+    case TF_CANCELLED: strcpy(error,"cancelled");
+      break;
+    case TF_UNKNOWN: strcpy(error,"unknown");
+      break;
+    case TF_INVALID_ARGUMENT: strcpy(error,"invalid_argument");
+      break;
+    case TF_DEADLINE_EXCEEDED: strcpy(error,"deadline_exceeded");
+      break;
+    case TF_NOT_FOUND: strcpy(error,"not_found");
+      break;
+    case TF_ALREADY_EXISTS: strcpy(error, "already_exists");
+      break;
+    case TF_PERMISSION_DENIED: strcpy(error,"permission_denied");
+      break;
+    case TF_UNAUTHENTICATED: strcpy(error,"unauthenticated");
+      break;
+    case TF_RESOURCE_EXHAUSTED: strcpy(error,"resource_exhausted");
+      break;
+    case TF_FAILED_PRECONDITION: strcpy(error,"failed_precondition");
+      break;
+    case TF_ABORTED: strcpy(error,"aborted");
+      break;
+    case TF_OUT_OF_RANGE: strcpy(error,"out_of_range");
+      break;
+    case TF_UNIMPLEMENTED: strcpy(error,"unimplemented");
+      break;
+    case TF_INTERNAL: strcpy(error,"internal");
+      break;
+    case TF_UNAVAILABLE: strcpy(error,"unavailable");
+      break;
+    case TF_DATA_LOSS: strcpy(error,"data_loss");
+      break;
+    default: strcpy(error,"unlisted_code");
+    }
+  
+  return error;
+}
+
 static ERL_NIF_TERM read_graph(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
   ErlNifBinary filepath;
@@ -148,7 +189,10 @@ static ERL_NIF_TERM read_graph(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv
   
   TF_GraphImportGraphDef(graph, buf, graph_opts, status);
   if (TF_GetCode(status) != TF_OK) {
-    return enif_make_tuple2(env,enif_make_atom(env,"error"),enif_make_string(env, "Unable to import graph", ERL_NIF_LATIN1));
+
+    char error_str[BASE_STRING_LENGTH];
+    error_to_string(status, error_str);
+    return enif_make_tuple2(env,enif_make_atom(env,"error"),enif_make_atom(env,error_str));
   }
   else {
     fprintf(stderr, "Successfully imported graph\n");
@@ -162,19 +206,37 @@ static ERL_NIF_TERM read_graph(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv
   
 }
 
-static ERL_NIF_TERM print_graph_ops(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+static ERL_NIF_TERM get_graph_ops(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
   TF_Graph **graph;
   enif_get_resource(env, argv[0], graph_resource, (void *) &graph);
 
+  int n_ops = 0;
   size_t pos = 0;
-  TF_Operation* op;
-  while ((op = TF_GraphNextOperation(*graph, &pos)) != NULL) {
-    fprintf(stderr, "%s\n",TF_OperationName(op));	
+  TF_Operation *op_count;
+  while ((op_count = TF_GraphNextOperation(*graph, &pos)) != NULL) {
+    n_ops++;
   }
 
-  return enif_make_atom(env,"ok");
+  ERL_NIF_TERM *op_list;
+  ERL_NIF_TERM op_list_eterm;
+  TF_Operation *op_temp;
+  ErlNifBinary erl_str;
+  op_list = malloc(sizeof(ERL_NIF_TERM)*n_ops);
+  pos = 0;
   
+  char op_name[BASE_STRING_LENGTH];
+  for(int i=0; i<n_ops; i++) {
+    op_temp = TF_GraphNextOperation(*graph, &pos);
+    strcpy(op_name, (char*) TF_OperationName(op_temp));
+    enif_alloc_binary(strlen(op_name), &erl_str);
+    memcpy(erl_str.data, op_name, strlen(op_name));
+    op_list[i] = enif_make_binary(env,&erl_str);
+  }
+
+  op_list_eterm = enif_make_list_from_array(env, op_list, n_ops);
+  free(op_list);
+  return op_list_eterm;
 }
 
 static ERL_NIF_TERM create_and_run_sess(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
@@ -222,12 +284,8 @@ static ERL_NIF_TERM create_and_run_sess(ErlNifEnv *env, int argc, const ERL_NIF_
 static ErlNifFunc nif_funcs[] =
   {
     { "version", 0, version },
-    { "new_graph", 0, new_graph },
-    { "new_op", 3, new_op },
     { "read_graph", 1, read_graph },
-    { "print_graph_ops", 1, print_graph_ops },
-    { "string_constant", 1, string_constant },
-    { "create_and_run_sess", 3, create_and_run_sess }
+    { "get_graph_ops", 1, get_graph_ops },
   };
 
 ERL_NIF_INIT(Elixir.Tensorflex, nif_funcs, res_loader, NULL, NULL, NULL)

--- a/lib/tensorflex.ex
+++ b/lib/tensorflex.ex
@@ -21,6 +21,10 @@ defmodule Tensorflex do
     raise "NIF read_graph/1 not implemented"
   end
 
+  def print_graph_ops(_graph) do
+    raise "NIF print_graph_ops/1 not implemented"
+  end
+
   def string_constant(_value) do
     raise "NIF tf_string_constant/1 not implemented"
   end

--- a/lib/tensorflex.ex
+++ b/lib/tensorflex.ex
@@ -9,28 +9,12 @@ defmodule Tensorflex do
     raise "NIF tf_version/0 not implemented"
   end
 
-  def new_graph do
-    raise "NIF tf_new_graph/0 not implemented"
-  end
-
-  def new_op(_graph, _op, _label) do
-    raise "NIF tf_new_op/3 not implemented"
-  end
-
   def read_graph(_filepath) do
     raise "NIF read_graph/1 not implemented"
   end
 
-  def print_graph_ops(_graph) do
-    raise "NIF print_graph_ops/1 not implemented"
+  def get_graph_ops(_graph) do
+    raise "NIF get_graph_ops/1 not implemented"
   end
-
-  def string_constant(_value) do
-    raise "NIF tf_string_constant/1 not implemented"
-  end
-
-  def create_and_run_sess(_graph, _opdesc, _tensor) do
-    raise "NIF tf_create_and_run_sess/3 not implemented"
-  end
-
+  
 end


### PR DESCRIPTION
@josevalim, this is the first (and most obvious) graph manipulation function that came to mind. After the predefined graph has been loaded, the user would like to know all possible operations that exist in the graph by name. The reasons for this could be many, but the foremost one being that Tensorflow allows users to get operations directly via their names. For that, a user would need something like this `print_graph_ops` function to list the operations by name and in the order in which they are 'stacked' in the graph definition.

As an example on the Imagenet model, this looks something like this:
```elixir
iex(1)> graph = Tensorflex.read_graph("classify_image_graph_def.pb")
2018-05-17 23:36:16.488469: I tensorflow/core/platform/cpu_feature_guard.cc:137] Your CPU supports instructions that    this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA 2018-05-17 23:36:16.774442: W             tensorflow/core/framework/op_def_util.cc:334] OpBatchNormWithGlobalNormalization is deprecated. It will cease to work in   GraphDef version 9. Use tf.nn.batch_normalization().
Successfully imported graph
#Reference<0.1610607974.1988231169.250293>

iex(2)> Tensorflex.print_graph_ops(graph)
softmax/biases 
softmax/weights 
pool_3/_reshape/shape 
mixed_10/join/concat_dim 
mixed_10/tower_2/conv/batchnorm/moving_variance 
mixed_10/tower_2/conv/batchnorm/moving_mean 
mixed_10/tower_2/conv/batchnorm/gamma 
mixed_10/tower_2/conv/batchnorm/beta 
mixed_10/tower_2/conv/conv2d_params 
mixed_10/tower_1/mixed/conv_1/batchnorm/moving_variance 
mixed_10/tower_1/mixed/conv_1/batchnorm/moving_mean 
mixed_10/tower_1/mixed/conv_1/batchnorm/gamma 
mixed_10/tower_1/mixed/conv_1/batchnorm/beta 
mixed_10/tower_1/mixed/conv_1/conv2d_params 
mixed_10/tower_1/mixed/conv/batchnorm/moving_variance 
mixed_10/tower_1/mixed/conv/batchnorm/moving_mean 
mixed_10/tower_1/mixed/conv/batchnorm/gamma 
mixed_10/tower_1/mixed/conv/batchnorm/beta 
mixed_10/tower_1/mixed/conv/conv2d_params 
mixed_10/tower_1/conv_1/batchnorm/moving_variance 
mixed_10/tower_1/conv_1/batchnorm/moving_mean 
mixed_10/tower_1/conv_1/batchnorm/gamma 
mixed_10/tower_1/conv_1/batchnorm/beta 
mixed_10/tower_1/conv_1/conv2d_params 
mixed_10/tower_1/conv/batchnorm/moving_variance 
mixed_10/tower_1/conv/batchnorm/moving_mean 
mixed_10/tower_1/conv/batchnorm/gamma 
mixed_10/tower_1/conv/batchnorm/beta 
mixed_10/tower_1/conv/conv2d_params 
mixed_10/tower/mixed/conv_1/batchnorm/moving_variance 
mixed_10/tower/mixed/conv_1/batchnorm/moving_mean 
mixed_10/tower/mixed/conv_1/batchnorm/gamma 
mixed_10/tower/mixed/conv_1/batchnorm/beta 
mixed_10/tower/mixed/conv_1/conv2d_params 
mixed_10/tower/mixed/conv/batchnorm/moving_variance 
mixed_10/tower/mixed/conv/batchnorm/moving_mean 
mixed_10/tower/mixed/conv/batchnorm/gamma 
mixed_10/tower/mixed/conv/batchnorm/beta 
mixed_10/tower/mixed/conv/conv2d_params 
mixed_10/tower/conv/batchnorm/moving_variance 
mixed_10/tower/conv/batchnorm/moving_mean 
mixed_10/tower/conv/batchnorm/gamma 
mixed_10/tower/conv/batchnorm/beta 
mixed_10/tower/conv/conv2d_params 
mixed_10/conv/batchnorm/moving_variance 
mixed_10/conv/batchnorm/moving_mean 
mixed_10/conv/batchnorm/gamma 
mixed_10/conv/batchnorm/beta 
mixed_10/conv/conv2d_params 
mixed_9/join/concat_dim 
mixed_9/tower_2/conv/batchnorm/moving_variance 
mixed_9/tower_2/conv/batchnorm/moving_mean 
mixed_9/tower_2/conv/batchnorm/gamma 
mixed_9/tower_2/conv/batchnorm/beta 
mixed_9/tower_2/conv/conv2d_params 
mixed_9/tower_1/mixed/conv_1/batchnorm/moving_variance 
mixed_9/tower_1/mixed/conv_1/batchnorm/moving_mean 
mixed_9/tower_1/mixed/conv_1/batchnorm/gamma 
mixed_9/tower_1/mixed/conv_1/batchnorm/beta 
mixed_9/tower_1/mixed/conv_1/conv2d_params 
mixed_9/tower_1/mixed/conv/batchnorm/moving_variance 
mixed_9/tower_1/mixed/conv/batchnorm/moving_mean 
mixed_9/tower_1/mixed/conv/batchnorm/gamma 
mixed_9/tower_1/mixed/conv/batchnorm/beta 
mixed_9/tower_1/mixed/conv/conv2d_params 
mixed_9/tower_1/conv_1/batchnorm/moving_variance 
mixed_9/tower_1/conv_1/batchnorm/moving_mean 
mixed_9/tower_1/conv_1/batchnorm/gamma 
mixed_9/tower_1/conv_1/batchnorm/beta 
mixed_9/tower_1/conv_1/conv2d_params 
mixed_9/tower_1/conv/batchnorm/moving_variance 
mixed_9/tower_1/conv/batchnorm/moving_mean 
mixed_9/tower_1/conv/batchnorm/gamma 
mixed_9/tower_1/conv/batchnorm/beta 
mixed_9/tower_1/conv/conv2d_params 
mixed_9/tower/mixed/conv_1/batchnorm/moving_variance 
mixed_9/tower/mixed/conv_1/batchnorm/moving_mean 
mixed_9/tower/mixed/conv_1/batchnorm/gamma 
mixed_9/tower/mixed/conv_1/batchnorm/beta 
mixed_9/tower/mixed/conv_1/conv2d_params 
mixed_9/tower/mixed/conv/batchnorm/moving_variance 
mixed_9/tower/mixed/conv/batchnorm/moving_mean 
mixed_9/tower/mixed/conv/batchnorm/gamma 
mixed_9/tower/mixed/conv/batchnorm/beta 
mixed_9/tower/mixed/conv/conv2d_params 
mixed_9/tower/conv/batchnorm/moving_variance 
mixed_9/tower/conv/batchnorm/moving_mean 
mixed_9/tower/conv/batchnorm/gamma 
mixed_9/tower/conv/batchnorm/beta 
mixed_9/tower/conv/conv2d_params 
mixed_9/conv/batchnorm/moving_variance 
mixed_9/conv/batchnorm/moving_mean 
mixed_9/conv/batchnorm/gamma 
mixed_9/conv/batchnorm/beta 
mixed_9/conv/conv2d_params 
mixed_8/join/concat_dim 
mixed_8/tower_1/conv_3/batchnorm/moving_variance 
mixed_8/tower_1/conv_3/batchnorm/moving_mean 
mixed_8/tower_1/conv_3/batchnorm/gamma 
mixed_8/tower_1/conv_3/batchnorm/beta 
mixed_8/tower_1/conv_3/conv2d_params 
mixed_8/tower_1/conv_2/batchnorm/moving_variance 
mixed_8/tower_1/conv_2/batchnorm/moving_mean 
mixed_8/tower_1/conv_2/batchnorm/gamma 
mixed_8/tower_1/conv_2/batchnorm/beta 
mixed_8/tower_1/conv_2/conv2d_params 
mixed_8/tower_1/conv_1/batchnorm/moving_variance 
mixed_8/tower_1/conv_1/batchnorm/moving_mean 
mixed_8/tower_1/conv_1/batchnorm/gamma 
mixed_8/tower_1/conv_1/batchnorm/beta 
mixed_8/tower_1/conv_1/conv2d_params 
mixed_8/tower_1/conv/batchnorm/moving_variance 
mixed_8/tower_1/conv/batchnorm/moving_mean 
mixed_8/tower_1/conv/batchnorm/gamma 
mixed_8/tower_1/conv/batchnorm/beta 
mixed_8/tower_1/conv/conv2d_params 
mixed_8/tower/conv_1/batchnorm/moving_variance 
mixed_8/tower/conv_1/batchnorm/moving_mean 
mixed_8/tower/conv_1/batchnorm/gamma 
mixed_8/tower/conv_1/batchnorm/beta 
mixed_8/tower/conv_1/conv2d_params 
mixed_8/tower/conv/batchnorm/moving_variance 
mixed_8/tower/conv/batchnorm/moving_mean 
mixed_8/tower/conv/batchnorm/gamma 
mixed_8/tower/conv/batchnorm/beta 
mixed_8/tower/conv/conv2d_params 
mixed_7/join/concat_dim 
mixed_7/tower_2/conv/batchnorm/moving_variance 
mixed_7/tower_2/conv/batchnorm/moving_mean 
mixed_7/tower_2/conv/batchnorm/gamma 
mixed_7/tower_2/conv/batchnorm/beta 
mixed_7/tower_2/conv/conv2d_params 
mixed_7/tower_1/conv_4/batchnorm/moving_variance 
mixed_7/tower_1/conv_4/batchnorm/moving_mean 
mixed_7/tower_1/conv_4/batchnorm/gamma 
mixed_7/tower_1/conv_4/batchnorm/beta 
mixed_7/tower_1/conv_4/conv2d_params 
mixed_7/tower_1/conv_3/batchnorm/moving_variance 
mixed_7/tower_1/conv_3/batchnorm/moving_mean 
mixed_7/tower_1/conv_3/batchnorm/gamma 
mixed_7/tower_1/conv_3/batchnorm/beta 
mixed_7/tower_1/conv_3/conv2d_params 
mixed_7/tower_1/conv_2/batchnorm/moving_variance 
mixed_7/tower_1/conv_2/batchnorm/moving_mean 
mixed_7/tower_1/conv_2/batchnorm/gamma 
mixed_7/tower_1/conv_2/batchnorm/beta 
mixed_7/tower_1/conv_2/conv2d_params 
mixed_7/tower_1/conv_1/batchnorm/moving_variance 
mixed_7/tower_1/conv_1/batchnorm/moving_mean 
mixed_7/tower_1/conv_1/batchnorm/gamma 
mixed_7/tower_1/conv_1/batchnorm/beta 
mixed_7/tower_1/conv_1/conv2d_params 
mixed_7/tower_1/conv/batchnorm/moving_variance 
mixed_7/tower_1/conv/batchnorm/moving_mean 
mixed_7/tower_1/conv/batchnorm/gamma 
mixed_7/tower_1/conv/batchnorm/beta 
mixed_7/tower_1/conv/conv2d_params 
mixed_7/tower/conv_2/batchnorm/moving_variance 
mixed_7/tower/conv_2/batchnorm/moving_mean 
mixed_7/tower/conv_2/batchnorm/gamma 
mixed_7/tower/conv_2/batchnorm/beta 
mixed_7/tower/conv_2/conv2d_params 
mixed_7/tower/conv_1/batchnorm/moving_variance 
mixed_7/tower/conv_1/batchnorm/moving_mean 
mixed_7/tower/conv_1/batchnorm/gamma 
mixed_7/tower/conv_1/batchnorm/beta 
mixed_7/tower/conv_1/conv2d_params 
mixed_7/tower/conv/batchnorm/moving_variance 
mixed_7/tower/conv/batchnorm/moving_mean 
mixed_7/tower/conv/batchnorm/gamma 
mixed_7/tower/conv/batchnorm/beta 
mixed_7/tower/conv/conv2d_params 
mixed_7/conv/batchnorm/moving_variance 
mixed_7/conv/batchnorm/moving_mean 
mixed_7/conv/batchnorm/gamma 
mixed_7/conv/batchnorm/beta 
mixed_7/conv/conv2d_params 
mixed_6/join/concat_dim 
mixed_6/tower_2/conv/batchnorm/moving_variance 
mixed_6/tower_2/conv/batchnorm/moving_mean 
mixed_6/tower_2/conv/batchnorm/gamma 
mixed_6/tower_2/conv/batchnorm/beta 
mixed_6/tower_2/conv/conv2d_params 
mixed_6/tower_1/conv_4/batchnorm/moving_variance 
mixed_6/tower_1/conv_4/batchnorm/moving_mean 
mixed_6/tower_1/conv_4/batchnorm/gamma 
mixed_6/tower_1/conv_4/batchnorm/beta 
mixed_6/tower_1/conv_4/conv2d_params 
mixed_6/tower_1/conv_3/batchnorm/moving_variance 
mixed_6/tower_1/conv_3/batchnorm/moving_mean 
mixed_6/tower_1/conv_3/batchnorm/gamma 
mixed_6/tower_1/conv_3/batchnorm/beta 
mixed_6/tower_1/conv_3/conv2d_params 
mixed_6/tower_1/conv_2/batchnorm/moving_variance 
mixed_6/tower_1/conv_2/batchnorm/moving_mean 
mixed_6/tower_1/conv_2/batchnorm/gamma 
mixed_6/tower_1/conv_2/batchnorm/beta 
mixed_6/tower_1/conv_2/conv2d_params 
mixed_6/tower_1/conv_1/batchnorm/moving_variance 
mixed_6/tower_1/conv_1/batchnorm/moving_mean 
mixed_6/tower_1/conv_1/batchnorm/gamma 
mixed_6/tower_1/conv_1/batchnorm/beta 
mixed_6/tower_1/conv_1/conv2d_params 
mixed_6/tower_1/conv/batchnorm/moving_variance 
mixed_6/tower_1/conv/batchnorm/moving_mean 
mixed_6/tower_1/conv/batchnorm/gamma 
mixed_6/tower_1/conv/batchnorm/beta 
mixed_6/tower_1/conv/conv2d_params 
mixed_6/tower/conv_2/batchnorm/moving_variance 
mixed_6/tower/conv_2/batchnorm/moving_mean 
mixed_6/tower/conv_2/batchnorm/gamma 
mixed_6/tower/conv_2/batchnorm/beta 
mixed_6/tower/conv_2/conv2d_params 
mixed_6/tower/conv_1/batchnorm/moving_variance 
mixed_6/tower/conv_1/batchnorm/moving_mean 
mixed_6/tower/conv_1/batchnorm/gamma 
mixed_6/tower/conv_1/batchnorm/beta 
mixed_6/tower/conv_1/conv2d_params 
mixed_6/tower/conv/batchnorm/moving_variance 
mixed_6/tower/conv/batchnorm/moving_mean 
mixed_6/tower/conv/batchnorm/gamma 
mixed_6/tower/conv/batchnorm/beta 
mixed_6/tower/conv/conv2d_params 
mixed_6/conv/batchnorm/moving_variance 
mixed_6/conv/batchnorm/moving_mean 
mixed_6/conv/batchnorm/gamma 
mixed_6/conv/batchnorm/beta 
mixed_6/conv/conv2d_params 
mixed_5/join/concat_dim 
mixed_5/tower_2/conv/batchnorm/moving_variance 
mixed_5/tower_2/conv/batchnorm/moving_mean 
mixed_5/tower_2/conv/batchnorm/gamma 
mixed_5/tower_2/conv/batchnorm/beta 
mixed_5/tower_2/conv/conv2d_params 
mixed_5/tower_1/conv_4/batchnorm/moving_variance 
mixed_5/tower_1/conv_4/batchnorm/moving_mean 
mixed_5/tower_1/conv_4/batchnorm/gamma 
mixed_5/tower_1/conv_4/batchnorm/beta 
mixed_5/tower_1/conv_4/conv2d_params 
mixed_5/tower_1/conv_3/batchnorm/moving_variance 
mixed_5/tower_1/conv_3/batchnorm/moving_mean 
mixed_5/tower_1/conv_3/batchnorm/gamma 
mixed_5/tower_1/conv_3/batchnorm/beta 
mixed_5/tower_1/conv_3/conv2d_params 
mixed_5/tower_1/conv_2/batchnorm/moving_variance 
mixed_5/tower_1/conv_2/batchnorm/moving_mean 
mixed_5/tower_1/conv_2/batchnorm/gamma 
mixed_5/tower_1/conv_2/batchnorm/beta 
mixed_5/tower_1/conv_2/conv2d_params 
mixed_5/tower_1/conv_1/batchnorm/moving_variance 
mixed_5/tower_1/conv_1/batchnorm/moving_mean 
mixed_5/tower_1/conv_1/batchnorm/gamma 
mixed_5/tower_1/conv_1/batchnorm/beta 
mixed_5/tower_1/conv_1/conv2d_params 
mixed_5/tower_1/conv/batchnorm/moving_variance 
mixed_5/tower_1/conv/batchnorm/moving_mean 
mixed_5/tower_1/conv/batchnorm/gamma 
mixed_5/tower_1/conv/batchnorm/beta 
mixed_5/tower_1/conv/conv2d_params 
mixed_5/tower/conv_2/batchnorm/moving_variance 
mixed_5/tower/conv_2/batchnorm/moving_mean 
mixed_5/tower/conv_2/batchnorm/gamma 
mixed_5/tower/conv_2/batchnorm/beta 
mixed_5/tower/conv_2/conv2d_params 
mixed_5/tower/conv_1/batchnorm/moving_variance 
mixed_5/tower/conv_1/batchnorm/moving_mean 
mixed_5/tower/conv_1/batchnorm/gamma 
mixed_5/tower/conv_1/batchnorm/beta 
mixed_5/tower/conv_1/conv2d_params 
mixed_5/tower/conv/batchnorm/moving_variance 
mixed_5/tower/conv/batchnorm/moving_mean 
mixed_5/tower/conv/batchnorm/gamma 
mixed_5/tower/conv/batchnorm/beta 
mixed_5/tower/conv/conv2d_params 
mixed_5/conv/batchnorm/moving_variance 
mixed_5/conv/batchnorm/moving_mean 
mixed_5/conv/batchnorm/gamma 
mixed_5/conv/batchnorm/beta 
mixed_5/conv/conv2d_params 
mixed_4/join/concat_dim 
mixed_4/tower_2/conv/batchnorm/moving_variance 
mixed_4/tower_2/conv/batchnorm/moving_mean 
mixed_4/tower_2/conv/batchnorm/gamma 
mixed_4/tower_2/conv/batchnorm/beta 
mixed_4/tower_2/conv/conv2d_params 
mixed_4/tower_1/conv_4/batchnorm/moving_variance 
mixed_4/tower_1/conv_4/batchnorm/moving_mean 
mixed_4/tower_1/conv_4/batchnorm/gamma 
mixed_4/tower_1/conv_4/batchnorm/beta 
mixed_4/tower_1/conv_4/conv2d_params 
mixed_4/tower_1/conv_3/batchnorm/moving_variance 
mixed_4/tower_1/conv_3/batchnorm/moving_mean 
mixed_4/tower_1/conv_3/batchnorm/gamma 
mixed_4/tower_1/conv_3/batchnorm/beta 
mixed_4/tower_1/conv_3/conv2d_params 
mixed_4/tower_1/conv_2/batchnorm/moving_variance 
mixed_4/tower_1/conv_2/batchnorm/moving_mean 
mixed_4/tower_1/conv_2/batchnorm/gamma 
mixed_4/tower_1/conv_2/batchnorm/beta 
mixed_4/tower_1/conv_2/conv2d_params 
mixed_4/tower_1/conv_1/batchnorm/moving_variance 
mixed_4/tower_1/conv_1/batchnorm/moving_mean 
mixed_4/tower_1/conv_1/batchnorm/gamma 
mixed_4/tower_1/conv_1/batchnorm/beta 
mixed_4/tower_1/conv_1/conv2d_params 
mixed_4/tower_1/conv/batchnorm/moving_variance 
mixed_4/tower_1/conv/batchnorm/moving_mean 
mixed_4/tower_1/conv/batchnorm/gamma 
mixed_4/tower_1/conv/batchnorm/beta 
mixed_4/tower_1/conv/conv2d_params 
mixed_4/tower/conv_2/batchnorm/moving_variance 
mixed_4/tower/conv_2/batchnorm/moving_mean 
mixed_4/tower/conv_2/batchnorm/gamma 
mixed_4/tower/conv_2/batchnorm/beta 
mixed_4/tower/conv_2/conv2d_params 
mixed_4/tower/conv_1/batchnorm/moving_variance 
mixed_4/tower/conv_1/batchnorm/moving_mean 
mixed_4/tower/conv_1/batchnorm/gamma 
mixed_4/tower/conv_1/batchnorm/beta 
mixed_4/tower/conv_1/conv2d_params 
mixed_4/tower/conv/batchnorm/moving_variance 
mixed_4/tower/conv/batchnorm/moving_mean 
mixed_4/tower/conv/batchnorm/gamma 
mixed_4/tower/conv/batchnorm/beta 
mixed_4/tower/conv/conv2d_params 
mixed_4/conv/batchnorm/moving_variance 
mixed_4/conv/batchnorm/moving_mean 
mixed_4/conv/batchnorm/gamma 
mixed_4/conv/batchnorm/beta 
mixed_4/conv/conv2d_params 
mixed_3/join/concat_dim 
mixed_3/tower/conv_2/batchnorm/moving_variance 
mixed_3/tower/conv_2/batchnorm/moving_mean 
mixed_3/tower/conv_2/batchnorm/gamma 
mixed_3/tower/conv_2/batchnorm/beta 
mixed_3/tower/conv_2/conv2d_params 
mixed_3/tower/conv_1/batchnorm/moving_variance 
mixed_3/tower/conv_1/batchnorm/moving_mean 
mixed_3/tower/conv_1/batchnorm/gamma 
mixed_3/tower/conv_1/batchnorm/beta 
mixed_3/tower/conv_1/conv2d_params 
mixed_3/tower/conv/batchnorm/moving_variance 
mixed_3/tower/conv/batchnorm/moving_mean 
mixed_3/tower/conv/batchnorm/gamma 
mixed_3/tower/conv/batchnorm/beta 
mixed_3/tower/conv/conv2d_params 
mixed_3/conv/batchnorm/moving_variance 
mixed_3/conv/batchnorm/moving_mean 
mixed_3/conv/batchnorm/gamma 
mixed_3/conv/batchnorm/beta 
mixed_3/conv/conv2d_params 
mixed_2/join/concat_dim 
mixed_2/tower_2/conv/batchnorm/moving_variance 
mixed_2/tower_2/conv/batchnorm/moving_mean 
mixed_2/tower_2/conv/batchnorm/gamma 
mixed_2/tower_2/conv/batchnorm/beta 
mixed_2/tower_2/conv/conv2d_params 
mixed_2/tower_1/conv_2/batchnorm/moving_variance 
mixed_2/tower_1/conv_2/batchnorm/moving_mean 
mixed_2/tower_1/conv_2/batchnorm/gamma 
mixed_2/tower_1/conv_2/batchnorm/beta 
mixed_2/tower_1/conv_2/conv2d_params 
mixed_2/tower_1/conv_1/batchnorm/moving_variance 
mixed_2/tower_1/conv_1/batchnorm/moving_mean 
mixed_2/tower_1/conv_1/batchnorm/gamma 
mixed_2/tower_1/conv_1/batchnorm/beta 
mixed_2/tower_1/conv_1/conv2d_params 
mixed_2/tower_1/conv/batchnorm/moving_variance 
mixed_2/tower_1/conv/batchnorm/moving_mean 
mixed_2/tower_1/conv/batchnorm/gamma 
mixed_2/tower_1/conv/batchnorm/beta 
mixed_2/tower_1/conv/conv2d_params 
mixed_2/tower/conv_1/batchnorm/moving_variance 
mixed_2/tower/conv_1/batchnorm/moving_mean 
mixed_2/tower/conv_1/batchnorm/gamma 
mixed_2/tower/conv_1/batchnorm/beta 
mixed_2/tower/conv_1/conv2d_params 
mixed_2/tower/conv/batchnorm/moving_variance 
mixed_2/tower/conv/batchnorm/moving_mean 
mixed_2/tower/conv/batchnorm/gamma 
mixed_2/tower/conv/batchnorm/beta 
mixed_2/tower/conv/conv2d_params 
mixed_2/conv/batchnorm/moving_variance 
mixed_2/conv/batchnorm/moving_mean 
mixed_2/conv/batchnorm/gamma 
mixed_2/conv/batchnorm/beta 
mixed_2/conv/conv2d_params 
mixed_1/join/concat_dim 
mixed_1/tower_2/conv/batchnorm/moving_variance 
mixed_1/tower_2/conv/batchnorm/moving_mean 
mixed_1/tower_2/conv/batchnorm/gamma 
mixed_1/tower_2/conv/batchnorm/beta 
mixed_1/tower_2/conv/conv2d_params 
mixed_1/tower_1/conv_2/batchnorm/moving_variance 
mixed_1/tower_1/conv_2/batchnorm/moving_mean 
mixed_1/tower_1/conv_2/batchnorm/gamma 
mixed_1/tower_1/conv_2/batchnorm/beta 
mixed_1/tower_1/conv_2/conv2d_params 
mixed_1/tower_1/conv_1/batchnorm/moving_variance 
mixed_1/tower_1/conv_1/batchnorm/moving_mean 
mixed_1/tower_1/conv_1/batchnorm/gamma 
mixed_1/tower_1/conv_1/batchnorm/beta 
mixed_1/tower_1/conv_1/conv2d_params 
mixed_1/tower_1/conv/batchnorm/moving_variance 
mixed_1/tower_1/conv/batchnorm/moving_mean 
mixed_1/tower_1/conv/batchnorm/gamma 
mixed_1/tower_1/conv/batchnorm/beta 
mixed_1/tower_1/conv/conv2d_params 
mixed_1/tower/conv_1/batchnorm/moving_variance 
mixed_1/tower/conv_1/batchnorm/moving_mean 
mixed_1/tower/conv_1/batchnorm/gamma 
mixed_1/tower/conv_1/batchnorm/beta 
mixed_1/tower/conv_1/conv2d_params 
mixed_1/tower/conv/batchnorm/moving_variance 
mixed_1/tower/conv/batchnorm/moving_mean 
mixed_1/tower/conv/batchnorm/gamma 
mixed_1/tower/conv/batchnorm/beta 
mixed_1/tower/conv/conv2d_params 
mixed_1/conv/batchnorm/moving_variance 
mixed_1/conv/batchnorm/moving_mean 
mixed_1/conv/batchnorm/gamma 
mixed_1/conv/batchnorm/beta 
mixed_1/conv/conv2d_params 
mixed/join/concat_dim 
mixed/tower_2/conv/batchnorm/moving_variance 
mixed/tower_2/conv/batchnorm/moving_mean 
mixed/tower_2/conv/batchnorm/gamma 
mixed/tower_2/conv/batchnorm/beta 
mixed/tower_2/conv/conv2d_params 
mixed/tower_1/conv_2/batchnorm/moving_variance 
mixed/tower_1/conv_2/batchnorm/moving_mean 
mixed/tower_1/conv_2/batchnorm/gamma 
mixed/tower_1/conv_2/batchnorm/beta 
mixed/tower_1/conv_2/conv2d_params 
mixed/tower_1/conv_1/batchnorm/moving_variance 
mixed/tower_1/conv_1/batchnorm/moving_mean 
mixed/tower_1/conv_1/batchnorm/gamma 
mixed/tower_1/conv_1/batchnorm/beta 
mixed/tower_1/conv_1/conv2d_params 
mixed/tower_1/conv/batchnorm/moving_variance 
mixed/tower_1/conv/batchnorm/moving_mean 
mixed/tower_1/conv/batchnorm/gamma 
mixed/tower_1/conv/batchnorm/beta 
mixed/tower_1/conv/conv2d_params 
mixed/tower/conv_1/batchnorm/moving_variance 
mixed/tower/conv_1/batchnorm/moving_mean 
mixed/tower/conv_1/batchnorm/gamma 
mixed/tower/conv_1/batchnorm/beta 
mixed/tower/conv_1/conv2d_params 
mixed/tower/conv/batchnorm/moving_variance 
mixed/tower/conv/batchnorm/moving_mean 
mixed/tower/conv/batchnorm/gamma 
mixed/tower/conv/batchnorm/beta 
mixed/tower/conv/conv2d_params 
mixed/conv/batchnorm/moving_variance 
mixed/conv/batchnorm/moving_mean 
mixed/conv/batchnorm/gamma 
mixed/conv/batchnorm/beta 
mixed/conv/conv2d_params 
conv_4/batchnorm/moving_variance 
conv_4/batchnorm/moving_mean 
conv_4/batchnorm/gamma 
conv_4/batchnorm/beta 
conv_4/conv2d_params 
conv_3/batchnorm/moving_variance 
conv_3/batchnorm/moving_mean 
conv_3/batchnorm/gamma 
conv_3/batchnorm/beta 
conv_3/conv2d_params 
conv_2/batchnorm/moving_variance 
conv_2/batchnorm/moving_mean 
conv_2/batchnorm/gamma 
conv_2/batchnorm/beta 
conv_2/conv2d_params 
conv_1/batchnorm/moving_variance 
conv_1/batchnorm/moving_mean 
conv_1/batchnorm/gamma 
conv_1/batchnorm/beta 
conv_1/conv2d_params 
conv/batchnorm/moving_variance 
conv/batchnorm/moving_mean 
conv/batchnorm/gamma 
conv/batchnorm/beta 
conv/conv2d_params 
Mul/y 
Sub/y 
ResizeBilinear/size 
ExpandDims/dim 
DecodeJpeg/contents 
DecodeJpeg 
Cast 
ExpandDims 
ResizeBilinear 
Sub 
Mul 
conv/Conv2D 
conv/batchnorm 
conv/CheckNumerics 
conv/control_dependency 
conv 
conv_1/Conv2D 
conv_1/batchnorm 
conv_1/CheckNumerics 
conv_1/control_dependency 
conv_1 
conv_2/Conv2D 
conv_2/batchnorm 
conv_2/CheckNumerics 
conv_2/control_dependency 
conv_2 
pool/CheckNumerics 
pool/control_dependency 
pool 
conv_3/Conv2D 
conv_3/batchnorm 
conv_3/CheckNumerics 
conv_3/control_dependency 
conv_3 
conv_4/Conv2D 
conv_4/batchnorm 
conv_4/CheckNumerics 
conv_4/control_dependency 
conv_4 
pool_1/CheckNumerics 
pool_1/control_dependency 
pool_1 
mixed/tower_2/pool 
mixed/tower_2/conv/Conv2D 
mixed/tower_2/conv/batchnorm 
mixed/tower_2/conv/CheckNumerics 
mixed/tower_2/conv/control_dependency 
mixed/tower_2/conv 
mixed/tower_1/conv/Conv2D 
mixed/tower_1/conv/batchnorm 
mixed/tower_1/conv/CheckNumerics 
mixed/tower_1/conv/control_dependency 
mixed/tower_1/conv 
mixed/tower_1/conv_1/Conv2D 
mixed/tower_1/conv_1/batchnorm 
mixed/tower_1/conv_1/CheckNumerics 
mixed/tower_1/conv_1/control_dependency 
mixed/tower_1/conv_1 
mixed/tower_1/conv_2/Conv2D 
mixed/tower_1/conv_2/batchnorm 
mixed/tower_1/conv_2/CheckNumerics 
mixed/tower_1/conv_2/control_dependency 
mixed/tower_1/conv_2 
mixed/tower/conv/Conv2D 
mixed/tower/conv/batchnorm 
mixed/tower/conv/CheckNumerics 
mixed/tower/conv/control_dependency 
mixed/tower/conv 
mixed/tower/conv_1/Conv2D 
mixed/tower/conv_1/batchnorm 
mixed/tower/conv_1/CheckNumerics 
mixed/tower/conv_1/control_dependency 
mixed/tower/conv_1 
mixed/conv/Conv2D 
mixed/conv/batchnorm 
mixed/conv/CheckNumerics 
mixed/conv/control_dependency 
mixed/conv 
mixed/join 
mixed_1/tower_2/pool 
mixed_1/tower_2/conv/Conv2D 
mixed_1/tower_2/conv/batchnorm 
mixed_1/tower_2/conv/CheckNumerics 
mixed_1/tower_2/conv/control_dependency 
mixed_1/tower_2/conv 
mixed_1/tower_1/conv/Conv2D 
mixed_1/tower_1/conv/batchnorm 
mixed_1/tower_1/conv/CheckNumerics 
mixed_1/tower_1/conv/control_dependency 
mixed_1/tower_1/conv 
mixed_1/tower_1/conv_1/Conv2D 
mixed_1/tower_1/conv_1/batchnorm 
mixed_1/tower_1/conv_1/CheckNumerics 
mixed_1/tower_1/conv_1/control_dependency 
mixed_1/tower_1/conv_1 
mixed_1/tower_1/conv_2/Conv2D 
mixed_1/tower_1/conv_2/batchnorm 
mixed_1/tower_1/conv_2/CheckNumerics 
mixed_1/tower_1/conv_2/control_dependency 
mixed_1/tower_1/conv_2 
mixed_1/tower/conv/Conv2D 
mixed_1/tower/conv/batchnorm 
mixed_1/tower/conv/CheckNumerics 
mixed_1/tower/conv/control_dependency 
mixed_1/tower/conv 
mixed_1/tower/conv_1/Conv2D 
mixed_1/tower/conv_1/batchnorm 
mixed_1/tower/conv_1/CheckNumerics 
mixed_1/tower/conv_1/control_dependency 
mixed_1/tower/conv_1 
mixed_1/conv/Conv2D 
mixed_1/conv/batchnorm 
mixed_1/conv/CheckNumerics 
mixed_1/conv/control_dependency 
mixed_1/conv 
mixed_1/join 
mixed_2/tower_2/pool 
mixed_2/tower_2/conv/Conv2D 
mixed_2/tower_2/conv/batchnorm 
mixed_2/tower_2/conv/CheckNumerics 
mixed_2/tower_2/conv/control_dependency 
mixed_2/tower_2/conv 
mixed_2/tower_1/conv/Conv2D 
mixed_2/tower_1/conv/batchnorm 
mixed_2/tower_1/conv/CheckNumerics 
mixed_2/tower_1/conv/control_dependency 
mixed_2/tower_1/conv 
mixed_2/tower_1/conv_1/Conv2D 
mixed_2/tower_1/conv_1/batchnorm 
mixed_2/tower_1/conv_1/CheckNumerics 
mixed_2/tower_1/conv_1/control_dependency 
mixed_2/tower_1/conv_1 
mixed_2/tower_1/conv_2/Conv2D 
mixed_2/tower_1/conv_2/batchnorm 
mixed_2/tower_1/conv_2/CheckNumerics 
mixed_2/tower_1/conv_2/control_dependency 
mixed_2/tower_1/conv_2 
mixed_2/tower/conv/Conv2D 
mixed_2/tower/conv/batchnorm 
mixed_2/tower/conv/CheckNumerics 
mixed_2/tower/conv/control_dependency 
mixed_2/tower/conv 
mixed_2/tower/conv_1/Conv2D 
mixed_2/tower/conv_1/batchnorm 
mixed_2/tower/conv_1/CheckNumerics 
mixed_2/tower/conv_1/control_dependency 
mixed_2/tower/conv_1 
mixed_2/conv/Conv2D 
mixed_2/conv/batchnorm 
mixed_2/conv/CheckNumerics 
mixed_2/conv/control_dependency 
mixed_2/conv 
mixed_2/join 
mixed_3/pool/CheckNumerics 
mixed_3/pool/control_dependency 
mixed_3/pool 
mixed_3/tower/conv/Conv2D 
mixed_3/tower/conv/batchnorm 
mixed_3/tower/conv/CheckNumerics 
mixed_3/tower/conv/control_dependency 
mixed_3/tower/conv 
mixed_3/tower/conv_1/Conv2D 
mixed_3/tower/conv_1/batchnorm 
mixed_3/tower/conv_1/CheckNumerics 
mixed_3/tower/conv_1/control_dependency 
mixed_3/tower/conv_1 
mixed_3/tower/conv_2/Conv2D 
mixed_3/tower/conv_2/batchnorm 
mixed_3/tower/conv_2/CheckNumerics 
mixed_3/tower/conv_2/control_dependency 
mixed_3/tower/conv_2 
mixed_3/conv/Conv2D 
mixed_3/conv/batchnorm 
mixed_3/conv/CheckNumerics 
mixed_3/conv/control_dependency 
mixed_3/conv 
mixed_3/join 
mixed_4/tower_2/pool 
mixed_4/tower_2/conv/Conv2D 
mixed_4/tower_2/conv/batchnorm 
mixed_4/tower_2/conv/CheckNumerics 
mixed_4/tower_2/conv/control_dependency 
mixed_4/tower_2/conv 
mixed_4/tower_1/conv/Conv2D 
mixed_4/tower_1/conv/batchnorm 
mixed_4/tower_1/conv/CheckNumerics 
mixed_4/tower_1/conv/control_dependency 
mixed_4/tower_1/conv 
mixed_4/tower_1/conv_1/Conv2D 
mixed_4/tower_1/conv_1/batchnorm 
mixed_4/tower_1/conv_1/CheckNumerics 
mixed_4/tower_1/conv_1/control_dependency 
mixed_4/tower_1/conv_1 
mixed_4/tower_1/conv_2/Conv2D 
mixed_4/tower_1/conv_2/batchnorm 
mixed_4/tower_1/conv_2/CheckNumerics 
mixed_4/tower_1/conv_2/control_dependency 
mixed_4/tower_1/conv_2 
mixed_4/tower_1/conv_3/Conv2D 
mixed_4/tower_1/conv_3/batchnorm 
mixed_4/tower_1/conv_3/CheckNumerics 
mixed_4/tower_1/conv_3/control_dependency 
mixed_4/tower_1/conv_3 
mixed_4/tower_1/conv_4/Conv2D 
mixed_4/tower_1/conv_4/batchnorm 
mixed_4/tower_1/conv_4/CheckNumerics 
mixed_4/tower_1/conv_4/control_dependency 
mixed_4/tower_1/conv_4 
mixed_4/tower/conv/Conv2D 
mixed_4/tower/conv/batchnorm 
mixed_4/tower/conv/CheckNumerics 
mixed_4/tower/conv/control_dependency 
mixed_4/tower/conv 
mixed_4/tower/conv_1/Conv2D 
mixed_4/tower/conv_1/batchnorm 
mixed_4/tower/conv_1/CheckNumerics 
mixed_4/tower/conv_1/control_dependency 
mixed_4/tower/conv_1 
mixed_4/tower/conv_2/Conv2D 
mixed_4/tower/conv_2/batchnorm 
mixed_4/tower/conv_2/CheckNumerics 
mixed_4/tower/conv_2/control_dependency 
mixed_4/tower/conv_2 
mixed_4/conv/Conv2D 
mixed_4/conv/batchnorm 
mixed_4/conv/CheckNumerics 
mixed_4/conv/control_dependency 
mixed_4/conv 
mixed_4/join 
mixed_5/tower_2/pool 
mixed_5/tower_2/conv/Conv2D 
mixed_5/tower_2/conv/batchnorm 
mixed_5/tower_2/conv/CheckNumerics 
mixed_5/tower_2/conv/control_dependency 
mixed_5/tower_2/conv 
mixed_5/tower_1/conv/Conv2D 
mixed_5/tower_1/conv/batchnorm 
mixed_5/tower_1/conv/CheckNumerics 
mixed_5/tower_1/conv/control_dependency 
mixed_5/tower_1/conv 
mixed_5/tower_1/conv_1/Conv2D 
mixed_5/tower_1/conv_1/batchnorm 
mixed_5/tower_1/conv_1/CheckNumerics 
mixed_5/tower_1/conv_1/control_dependency 
mixed_5/tower_1/conv_1 
mixed_5/tower_1/conv_2/Conv2D 
mixed_5/tower_1/conv_2/batchnorm 
mixed_5/tower_1/conv_2/CheckNumerics 
mixed_5/tower_1/conv_2/control_dependency 
mixed_5/tower_1/conv_2 
mixed_5/tower_1/conv_3/Conv2D 
mixed_5/tower_1/conv_3/batchnorm 
mixed_5/tower_1/conv_3/CheckNumerics 
mixed_5/tower_1/conv_3/control_dependency 
mixed_5/tower_1/conv_3 
mixed_5/tower_1/conv_4/Conv2D 
mixed_5/tower_1/conv_4/batchnorm 
mixed_5/tower_1/conv_4/CheckNumerics 
mixed_5/tower_1/conv_4/control_dependency 
mixed_5/tower_1/conv_4 
mixed_5/tower/conv/Conv2D 
mixed_5/tower/conv/batchnorm 
mixed_5/tower/conv/CheckNumerics 
mixed_5/tower/conv/control_dependency 
mixed_5/tower/conv 
mixed_5/tower/conv_1/Conv2D 
mixed_5/tower/conv_1/batchnorm 
mixed_5/tower/conv_1/CheckNumerics 
mixed_5/tower/conv_1/control_dependency 
mixed_5/tower/conv_1 
mixed_5/tower/conv_2/Conv2D 
mixed_5/tower/conv_2/batchnorm 
mixed_5/tower/conv_2/CheckNumerics 
mixed_5/tower/conv_2/control_dependency 
mixed_5/tower/conv_2 
mixed_5/conv/Conv2D 
mixed_5/conv/batchnorm 
mixed_5/conv/CheckNumerics 
mixed_5/conv/control_dependency 
mixed_5/conv 
mixed_5/join 
mixed_6/tower_2/pool 
mixed_6/tower_2/conv/Conv2D 
mixed_6/tower_2/conv/batchnorm 
mixed_6/tower_2/conv/CheckNumerics 
mixed_6/tower_2/conv/control_dependency 
mixed_6/tower_2/conv 
mixed_6/tower_1/conv/Conv2D 
mixed_6/tower_1/conv/batchnorm 
mixed_6/tower_1/conv/CheckNumerics 
mixed_6/tower_1/conv/control_dependency 
mixed_6/tower_1/conv 
mixed_6/tower_1/conv_1/Conv2D 
mixed_6/tower_1/conv_1/batchnorm 
mixed_6/tower_1/conv_1/CheckNumerics 
mixed_6/tower_1/conv_1/control_dependency 
mixed_6/tower_1/conv_1 
mixed_6/tower_1/conv_2/Conv2D 
mixed_6/tower_1/conv_2/batchnorm 
mixed_6/tower_1/conv_2/CheckNumerics 
mixed_6/tower_1/conv_2/control_dependency 
mixed_6/tower_1/conv_2 
mixed_6/tower_1/conv_3/Conv2D 
mixed_6/tower_1/conv_3/batchnorm 
mixed_6/tower_1/conv_3/CheckNumerics 
mixed_6/tower_1/conv_3/control_dependency 
mixed_6/tower_1/conv_3 
mixed_6/tower_1/conv_4/Conv2D 
mixed_6/tower_1/conv_4/batchnorm 
mixed_6/tower_1/conv_4/CheckNumerics 
mixed_6/tower_1/conv_4/control_dependency 
mixed_6/tower_1/conv_4 
mixed_6/tower/conv/Conv2D 
mixed_6/tower/conv/batchnorm 
mixed_6/tower/conv/CheckNumerics 
mixed_6/tower/conv/control_dependency 
mixed_6/tower/conv 
mixed_6/tower/conv_1/Conv2D 
mixed_6/tower/conv_1/batchnorm 
mixed_6/tower/conv_1/CheckNumerics 
mixed_6/tower/conv_1/control_dependency 
mixed_6/tower/conv_1 
mixed_6/tower/conv_2/Conv2D 
mixed_6/tower/conv_2/batchnorm 
mixed_6/tower/conv_2/CheckNumerics 
mixed_6/tower/conv_2/control_dependency 
mixed_6/tower/conv_2 
mixed_6/conv/Conv2D 
mixed_6/conv/batchnorm 
mixed_6/conv/CheckNumerics 
mixed_6/conv/control_dependency 
mixed_6/conv 
mixed_6/join 
mixed_7/tower_2/pool 
mixed_7/tower_2/conv/Conv2D 
mixed_7/tower_2/conv/batchnorm 
mixed_7/tower_2/conv/CheckNumerics 
mixed_7/tower_2/conv/control_dependency 
mixed_7/tower_2/conv 
mixed_7/tower_1/conv/Conv2D 
mixed_7/tower_1/conv/batchnorm 
mixed_7/tower_1/conv/CheckNumerics 
mixed_7/tower_1/conv/control_dependency 
mixed_7/tower_1/conv 
mixed_7/tower_1/conv_1/Conv2D 
mixed_7/tower_1/conv_1/batchnorm 
mixed_7/tower_1/conv_1/CheckNumerics 
mixed_7/tower_1/conv_1/control_dependency 
mixed_7/tower_1/conv_1 
mixed_7/tower_1/conv_2/Conv2D 
mixed_7/tower_1/conv_2/batchnorm 
mixed_7/tower_1/conv_2/CheckNumerics 
mixed_7/tower_1/conv_2/control_dependency 
mixed_7/tower_1/conv_2 
mixed_7/tower_1/conv_3/Conv2D 
mixed_7/tower_1/conv_3/batchnorm 
mixed_7/tower_1/conv_3/CheckNumerics 
mixed_7/tower_1/conv_3/control_dependency 
mixed_7/tower_1/conv_3 
mixed_7/tower_1/conv_4/Conv2D 
mixed_7/tower_1/conv_4/batchnorm 
mixed_7/tower_1/conv_4/CheckNumerics 
mixed_7/tower_1/conv_4/control_dependency 
mixed_7/tower_1/conv_4 
mixed_7/tower/conv/Conv2D 
mixed_7/tower/conv/batchnorm 
mixed_7/tower/conv/CheckNumerics 
mixed_7/tower/conv/control_dependency 
mixed_7/tower/conv 
mixed_7/tower/conv_1/Conv2D 
mixed_7/tower/conv_1/batchnorm 
mixed_7/tower/conv_1/CheckNumerics 
mixed_7/tower/conv_1/control_dependency 
mixed_7/tower/conv_1 
mixed_7/tower/conv_2/Conv2D 
mixed_7/tower/conv_2/batchnorm 
mixed_7/tower/conv_2/CheckNumerics 
mixed_7/tower/conv_2/control_dependency 
mixed_7/tower/conv_2 
mixed_7/conv/Conv2D 
mixed_7/conv/batchnorm 
mixed_7/conv/CheckNumerics 
mixed_7/conv/control_dependency 
mixed_7/conv 
mixed_7/join 
mixed_8/pool/CheckNumerics 
mixed_8/pool/control_dependency 
mixed_8/pool 
mixed_8/tower_1/conv/Conv2D 
mixed_8/tower_1/conv/batchnorm 
mixed_8/tower_1/conv/CheckNumerics 
mixed_8/tower_1/conv/control_dependency 
mixed_8/tower_1/conv 
mixed_8/tower_1/conv_1/Conv2D 
mixed_8/tower_1/conv_1/batchnorm 
mixed_8/tower_1/conv_1/CheckNumerics 
mixed_8/tower_1/conv_1/control_dependency 
mixed_8/tower_1/conv_1 
mixed_8/tower_1/conv_2/Conv2D 
mixed_8/tower_1/conv_2/batchnorm 
mixed_8/tower_1/conv_2/CheckNumerics 
mixed_8/tower_1/conv_2/control_dependency 
mixed_8/tower_1/conv_2 
mixed_8/tower_1/conv_3/Conv2D 
mixed_8/tower_1/conv_3/batchnorm 
mixed_8/tower_1/conv_3/CheckNumerics 
mixed_8/tower_1/conv_3/control_dependency 
mixed_8/tower_1/conv_3 
mixed_8/tower/conv/Conv2D 
mixed_8/tower/conv/batchnorm 
mixed_8/tower/conv/CheckNumerics 
mixed_8/tower/conv/control_dependency 
mixed_8/tower/conv 
mixed_8/tower/conv_1/Conv2D 
mixed_8/tower/conv_1/batchnorm 
mixed_8/tower/conv_1/CheckNumerics 
mixed_8/tower/conv_1/control_dependency 
mixed_8/tower/conv_1 
mixed_8/join 
mixed_9/tower_2/pool 
mixed_9/tower_2/conv/Conv2D 
mixed_9/tower_2/conv/batchnorm 
mixed_9/tower_2/conv/CheckNumerics 
mixed_9/tower_2/conv/control_dependency 
mixed_9/tower_2/conv 
mixed_9/tower_1/conv/Conv2D 
mixed_9/tower_1/conv/batchnorm 
mixed_9/tower_1/conv/CheckNumerics 
mixed_9/tower_1/conv/control_dependency 
mixed_9/tower_1/conv 
mixed_9/tower_1/conv_1/Conv2D 
mixed_9/tower_1/conv_1/batchnorm 
mixed_9/tower_1/conv_1/CheckNumerics 
mixed_9/tower_1/conv_1/control_dependency 
mixed_9/tower_1/conv_1 
mixed_9/tower_1/mixed/conv_1/Conv2D 
mixed_9/tower_1/mixed/conv_1/batchnorm 
mixed_9/tower_1/mixed/conv_1/CheckNumerics 
mixed_9/tower_1/mixed/conv_1/control_dependency 
mixed_9/tower_1/mixed/conv_1 
mixed_9/tower_1/mixed/conv/Conv2D 
mixed_9/tower_1/mixed/conv/batchnorm 
mixed_9/tower_1/mixed/conv/CheckNumerics 
mixed_9/tower_1/mixed/conv/control_dependency 
mixed_9/tower_1/mixed/conv 
mixed_9/tower/conv/Conv2D 
mixed_9/tower/conv/batchnorm 
mixed_9/tower/conv/CheckNumerics 
mixed_9/tower/conv/control_dependency 
mixed_9/tower/conv 
mixed_9/tower/mixed/conv_1/Conv2D 
mixed_9/tower/mixed/conv_1/batchnorm 
mixed_9/tower/mixed/conv_1/CheckNumerics 
mixed_9/tower/mixed/conv_1/control_dependency 
mixed_9/tower/mixed/conv_1 
mixed_9/tower/mixed/conv/Conv2D 
mixed_9/tower/mixed/conv/batchnorm 
mixed_9/tower/mixed/conv/CheckNumerics 
mixed_9/tower/mixed/conv/control_dependency 
mixed_9/tower/mixed/conv 
mixed_9/conv/Conv2D 
mixed_9/conv/batchnorm 
mixed_9/conv/CheckNumerics 
mixed_9/conv/control_dependency 
mixed_9/conv 
mixed_9/join 
mixed_10/tower_2/pool/CheckNumerics 
mixed_10/tower_2/pool/control_dependency 
mixed_10/tower_2/pool 
mixed_10/tower_2/conv/Conv2D 
mixed_10/tower_2/conv/batchnorm 
mixed_10/tower_2/conv/CheckNumerics 
mixed_10/tower_2/conv/control_dependency 
mixed_10/tower_2/conv 
mixed_10/tower_1/conv/Conv2D 
mixed_10/tower_1/conv/batchnorm 
mixed_10/tower_1/conv/CheckNumerics 
mixed_10/tower_1/conv/control_dependency 
mixed_10/tower_1/conv 
mixed_10/tower_1/conv_1/Conv2D 
mixed_10/tower_1/conv_1/batchnorm 
mixed_10/tower_1/conv_1/CheckNumerics 
mixed_10/tower_1/conv_1/control_dependency 
mixed_10/tower_1/conv_1 
mixed_10/tower_1/mixed/conv_1/Conv2D 
mixed_10/tower_1/mixed/conv_1/batchnorm 
mixed_10/tower_1/mixed/conv_1/CheckNumerics 
mixed_10/tower_1/mixed/conv_1/control_dependency 
mixed_10/tower_1/mixed/conv_1 
mixed_10/tower_1/mixed/conv/Conv2D 
mixed_10/tower_1/mixed/conv/batchnorm 
mixed_10/tower_1/mixed/conv/CheckNumerics 
mixed_10/tower_1/mixed/conv/control_dependency 
mixed_10/tower_1/mixed/conv 
mixed_10/tower/conv/Conv2D 
mixed_10/tower/conv/batchnorm 
mixed_10/tower/conv/CheckNumerics 
mixed_10/tower/conv/control_dependency 
mixed_10/tower/conv 
mixed_10/tower/mixed/conv_1/Conv2D 
mixed_10/tower/mixed/conv_1/batchnorm 
mixed_10/tower/mixed/conv_1/CheckNumerics 
mixed_10/tower/mixed/conv_1/control_dependency 
mixed_10/tower/mixed/conv_1 
mixed_10/tower/mixed/conv/Conv2D 
mixed_10/tower/mixed/conv/batchnorm 
mixed_10/tower/mixed/conv/CheckNumerics 
mixed_10/tower/mixed/conv/control_dependency 
mixed_10/tower/mixed/conv 
mixed_10/conv/Conv2D 
mixed_10/conv/batchnorm 
mixed_10/conv/CheckNumerics 
mixed_10/conv/control_dependency 
mixed_10/conv 
mixed_10/join 
pool_3 
pool_3/_reshape 
softmax/logits/MatMul 
softmax/logits 
softmax 

``` 