### PR TITLE
Added tensor support for strings and for getting TF_DataType

### DIFF
--- a/lib/tensorflex.ex
+++ b/lib/tensorflex.ex
@@ -8,7 +8,7 @@ defmodule Tensorflex do
   def version do
     raise "NIF tf_version/0 not implemented"
   end
-
+  
   def read_graph(_filepath) do
     raise "NIF read_graph/1 not implemented"
   end
@@ -16,5 +16,13 @@ defmodule Tensorflex do
   def get_graph_ops(_graph) do
     raise "NIF get_graph_ops/1 not implemented"
   end
-  
+
+  def string_tensor(_string) do
+    raise "NIF string_tensor/1 not implemented"
+  end
+
+  def tensor_datatype(_tensor) do
+    raise "NIF tensor_datatype/1 not implemented"
+  end
+
 end


### PR DESCRIPTION
@josevalim, In this PR I have added some functions that were working perfectly. However I have actually been devoting a lot of time to getting `TF_INT64` and `TF_FLOAT` tensors (especially multi-dimensional ones) to work in Elixir. I will add PRs for those soon, once I get them to work completely.

In this PR, the functionalities added are:
- __Support for string tensors__
- __Getting to know the datatype of a tensor__ (Will be useful later on, when Tensor support is varied across many datatypes. I have already added support for all datatypes in this function)

An example for these functions is as follows:
```elixir
iex(1)> tensor = Tensorflex.string_tensor "string tensors work!"
#Reference<0.697833995.47579139.50516>

iex(2)> tensor2 = Tensorflex.string_tensor 123
{:error, :non_binary_argument}

iex(3)> Tensorflex.tensor_datatype tensor
{:ok, :tf_string}

```