### PR TITLE
Added matrix functions, numeral tensors, better returns & removed unnecessary POC code

### DIFF
--- a/c_src/Tensorflex.c
+++ b/c_src/Tensorflex.c
@@ -438,7 +438,7 @@ static ERL_NIF_TERM float_tensor(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
 	}
     }
 
-    tensor = TF_NewTensor(TF_FLOAT, dims, ndims, mx1.p->data, (size_alloc) * sizeof(double), tensor_deallocator, 0);
+    tensor = TF_NewTensor(TF_DOUBLE, dims, ndims, mx1.p->data, (size_alloc) * sizeof(double), tensor_deallocator, 0);
 
   }
 

--- a/c_src/Tensorflex.c
+++ b/c_src/Tensorflex.c
@@ -416,7 +416,7 @@ static ERL_NIF_TERM float_tensor(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
   if (enif_is_number(env, argv[0])) {
     void *val = enif_alloc(sizeof(double));
     if (enif_get_double(env, argv[0], val)) {
-      tensor = TF_NewTensor(TF_FLOAT, 0, 0, val, sizeof(double), tensor_deallocator, 0);
+      tensor = TF_NewTensor(TF_DOUBLE, 0, 0, val, sizeof(double), tensor_deallocator, 0);
     } else return enif_make_badarg(env);
   }
 

--- a/lib/tensorflex.ex
+++ b/lib/tensorflex.ex
@@ -5,6 +5,22 @@ defmodule Tensorflex do
     :erlang.load_nif("priv/Tensorflex", 0)
   end
 
+  def create_matrix(_nrows,_ncolumns, _list) do
+    raise "NIF create_matrix/3 not implemented"
+  end
+
+  def matrix_pos(_matrix, _row, _column) do
+    raise "NIF matrix_pos/3 not implemented"
+  end
+
+  def size_of_matrix(_matrix) do
+    raise "NIF size_of_matrix/1 not implemented"
+  end
+
+  def matrix_to_lists(_matrix) do
+    raise "NIF matrix_to_term/1 not implemented"
+  end
+
   def version do
     raise "NIF tf_version/0 not implemented"
   end
@@ -15,6 +31,14 @@ defmodule Tensorflex do
 
   def get_graph_ops(_graph) do
     raise "NIF get_graph_ops/1 not implemented"
+  end
+
+  def float_tensor(_float) do
+    raise "NIF float_tensor/1 not implemented"
+  end
+
+  def float_tensor(_values, _dims) do
+    raise "NIF float_tensor/2 not implemented"
   end
 
   def string_tensor(_string) do


### PR DESCRIPTION
@josevalim, I have added a lot of functionality in this PR. I first give the high level overview of these functionalities and then the code follows at the end to exemplify them:

- __Matrix functions__: Since Elixir doesn't have something like Numpy in Python, we needed some matrix capabilities. I was actually writing most of this myself but then saw some examples in the Blackberry Erlang OTP which I adopted into the Tensorflex code base after some changes.
- __Tensor capabilities__: Numeral tensors are now fully supported. This makes use of the above matrix functions to achieve what is required
- __Improved return statements__: Wherever a successful return is being made, now a tuple with an `:ok` atom is returned and whenever the error is a case of bad input arguments I have switched to returning `enif_make_badarg`
- __Removed code from POC days__: A lot of code was just lying around that was not being used that was written by me pre-GSoC results, as part of the POC. I have removed this now.



**CODE EXAMPLES**
- Matrix functions:
    - Matrices are created using `create_matrix` which takes `number of rows`, `number of columns` and list(s) of matrix data as inputs
    - `matrix_pos` help get the value stored in the matrix at a particular row and column
    - `size_of_matrix` returns a tuple of the size of matrix as `{number of rows, number of columns}`
    - `matrix_to_lists` returns the data of the matrix as list of lists
```elixir
iex(1)> m = Tensorflex.create_matrix(2,3,[[2.2,1.3,44.5],[5.5,6.1,3.333]])
#Reference<0.1012898165.3475636225.187946>

iex(2)> Tensorflex.matrix_pos(m,2,1)
5.5

iex(3)> Tensorflex.size_of_matrix m
{2, 3}

iex(4)> Tensorflex.matrix_to_lists m
[[2.2, 1.3, 44.5], [5.5, 6.1, 3.333]]

```

- Numeral Tensors:
    - Basically `float_tensor` handles numeral tensors. It has two variants: one that takes in just 1 argument and the other which takes in 2 arguments
    - The one which takes 1 argument is just for making a tensor out of a single number
    - The 2 argument variant is actually more important and is used for multidimensional Tensors
    - Here, the first argument is the values and the second consists of the dimensions of the Tensor. Both these are matrices

```elixir
iex(1)> dims = Tensorflex.create_matrix(1,3,[[1,1,3]])
#Reference<0.3771206257.3662544900.104749>

iex(2)> vals = Tensorflex.create_matrix(1,3,[[245,202,9]])
#Reference<0.3771206257.3662544900.104769>

iex(3)> Tensorflex.float_tensor 123.12
{:ok, #Reference<0.3771206257.3662544897.110716>}

iex(4)> {:ok, ftensor} = Tensorflex.float_tensor(vals,dims)
{:ok, #Reference<0.3771206257.3662544897.111510>}

iex(5)> Tensorflex.tensor_datatype ftensor
{:ok, :tf_float}
```

- Better return statements:
    - Basically added the `:ok` atom to every successful return in a function, including all previously written functions
    - For incorrect input arguments, switched to returning `enif_make_badarg`
```elixir
iex(1)> Tensorflex.string_tensor 123
** (ArgumentError) argument error
    (tensorflex) Tensorflex.string_tensor(123)

iex(2)> Tensorflex.string_tensor "123"
{:ok, #Reference<0.3771206257.3662544897.113000>}
```