### PR TITLE
Tensors of TF_FLOAT and TF_DOUBLE type both supported

### DIFF
--- a/lib/tensorflex.ex
+++ b/lib/tensorflex.ex
@@ -33,12 +33,20 @@ defmodule Tensorflex do
     raise "NIF get_graph_ops/1 not implemented"
   end
 
-  def float_tensor(_float) do
-    raise "NIF float_tensor/1 not implemented"
+  def float64_tensor(_float) do
+    raise "NIF float_tensor64/1 not implemented"
   end
 
-  def float_tensor(_values, _dims) do
-    raise "NIF float_tensor/2 not implemented"
+  def float64_tensor(_values, _dims) do
+    raise "NIF float_tensor64/2 not implemented"
+  end
+
+  def float32_tensor(_float) do
+    raise "NIF float_tensor32/1 not implemented"
+  end
+
+  def float32_tensor(_values, _dims) do
+    raise "NIF float_tensor32/2 not implemented"
   end
 
   def string_tensor(_string) do


### PR DESCRIPTION
For the time being, both the `TF_FLOAT` and `TF_DOUBLE` tensor types are now supported. The matrices created are still 64 bit floats, though. I do not want to complicate the matrix functions right now, as at the end we will move to using Matrex more than the in-house Tensorflex matrix functions.

Next up: Support for Tensorflow Sessions!