### PR TITLE
Added Keras example

### DIFF
--- a/examples/keras-example/mnist_keras.py
+++ b/examples/keras-example/mnist_keras.py
@@ -1,0 +1,73 @@
+'''Trains a simple deep NN on the MNIST dataset.
+Gets to 98.40% test accuracy after 20 epochs
+(there is *a lot* of margin for parameter tuning).
+2 seconds per epoch on a K520 GPU.
+'''
+
+from __future__ import print_function
+import keras
+from keras.datasets import mnist
+from keras.models import Sequential
+from keras.layers import Dense, Dropout
+from keras.optimizers import RMSprop
+from tensorflow.python.framework.graph_util import convert_variables_to_constants
+from keras import backend
+import tensorflow as tf
+
+def freeze_session(session, keep_var_names=None, output_names=None, clear_devices=True):
+    graph = session.graph
+    with graph.as_default():
+        freeze_var_names = list(set(v.op.name for v in tf.global_variables()).difference(keep_var_names or []))
+        output_names = output_names or []
+        output_names += [v.op.name for v in tf.global_variables()]
+        input_graph_def = graph.as_graph_def()
+        if clear_devices:
+            for node in input_graph_def.node:
+                node.device = ""
+        frozen_graph = convert_variables_to_constants(session, input_graph_def, output_names, freeze_var_names)
+        return frozen_graph
+
+batch_size = 128
+num_classes = 10
+epochs = 20
+
+# the data, split between train and test sets
+(x_train, y_train), (x_test, y_test) = mnist.load_data()
+
+x_train = x_train.reshape(60000, 784)
+x_test = x_test.reshape(10000, 784)
+x_train = x_train.astype('float32')
+x_test = x_test.astype('float32')
+x_train /= 255
+x_test /= 255
+print(x_train.shape[0], 'train samples')
+print(x_test.shape[0], 'test samples')
+
+# convert class vectors to binary class matrices
+y_train = keras.utils.to_categorical(y_train, num_classes)
+y_test = keras.utils.to_categorical(y_test, num_classes)
+
+model = Sequential()
+model.add(Dense(512, activation='relu', input_shape=(784,), name="input"))
+model.add(Dropout(0.2))
+model.add(Dense(512, activation='relu'))
+model.add(Dropout(0.2))
+model.add(Dense(num_classes, activation='softmax', name="output"))
+
+model.summary()
+
+model.compile(loss='categorical_crossentropy',
+              optimizer=RMSprop(),
+              metrics=['accuracy'])
+
+history = model.fit(x_train, y_train,
+                    batch_size=batch_size,
+                    epochs=epochs,
+                    verbose=1,
+                    validation_data=(x_test, y_test))
+score = model.evaluate(x_test, y_test, verbose=0)
+print('Test loss:', score[0])
+print('Test accuracy:', score[1])
+
+frozen_graph = freeze_session(backend.get_session(), output_names=[out.op.name for out in model.outputs])
+tf.train.write_graph(frozen_graph, "./", "mnist_mlp.pb", as_text=False)


### PR DESCRIPTION
This example shows how to train a MLP model on the MNIST dataset from scratch in the Keras library and then save it as a .pb graph model for using it in Tensorflex. The MNIST dataset comes in built with the Keras library. I have basically modified one of the existing examples present on the Keras Github repository. The generated model can be read into Tensorflex as:

```elixir
iex(1)> {:ok, graph} = Tensorflex.read_graph("mnist_mlp.pb")
2018-07-15 15:16:26.542596: I tensorflow/core/platform/cpu_feature_guard.cc:137] Your CPU supports instructions that this TensorFlow binary was not compiled to use: SSE4.1 SSE4.2 AVX AVX2 FMA
                               {:ok,
 %Tensorflex.Graph{
   def: #Reference<0.4212261172.582352897.51740>,
   name: "mnist_mlp.pb"
 }}

iex(2)> Tensorflex.get_graph_ops graph
["Variable_5", "Variable_4", "Variable_3", "Variable_2", "Variable_1",
 "Variable", "iterations", "decay", "rho", "lr", "output/bias",
 "output/bias/read", "output/kernel", "output/kernel/read", "dense_1/bias",
 "dense_1/bias/read", "dense_1/kernel", "dense_1/kernel/read",
 "dropout_1/keras_learning_phase", "dropout_2/cond/pred_id",
 "dropout_2/cond/Switch", "dropout_2/cond/switch_t",
 "dropout_2/cond/dropout/random_uniform/max",
 "dropout_2/cond/dropout/random_uniform/min",
 "dropout_2/cond/dropout/random_uniform/sub",
 "dropout_2/cond/dropout/keep_prob", "dropout_2/cond/mul/y",
 "dropout_1/cond/pred_id", "dropout_1/cond/Switch", "dropout_1/cond/switch_t",
 "dropout_1/cond/dropout/random_uniform/max",
 "dropout_1/cond/dropout/random_uniform/min",
 "dropout_1/cond/dropout/random_uniform/sub",
 "dropout_1/cond/dropout/keep_prob", "dropout_1/cond/mul/y", "input/bias",
 "input/bias/read", "input/kernel", "input/kernel/read", "input_input",
 "input/MatMul", "input/BiasAdd", "input/Relu", "dropout_1/cond/Switch_1",
 "dropout_1/cond/mul/Switch", "dropout_1/cond/mul",
 "dropout_1/cond/dropout/Div", "dropout_1/cond/dropout/Shape",
 "dropout_1/cond/dropout/random_uniform/RandomUniform",
 "dropout_1/cond/dropout/random_uniform/mul", ...]
```

Keras makes some slight changes to our input and output operation names (since it is built on top of TF) but they are still easily decipherable. They are changed from `"input"` to `"input_input"` and from `"output"` to `"output/Softmax"`.

Once CSV support is added, a blog post can be written about the MNIST dataset and using Keras (or TF) models for the same.
