### PR TITLE
Fixed indentation and corrected warnings

### DIFF
--- a/lib/tensorflex.ex
+++ b/lib/tensorflex.ex
@@ -898,7 +898,7 @@ defmodule Tensorflex do
   arguments. Support for grayscale images and other image formats such as `PNG`
   will be added in the future. 
 
-## Examples
+  ## Examples
 
   To exemplify the working of the `load_image_as_tensor/1` function we will
   cover the entire prediction pipeline for the Inception model. However, this
@@ -992,7 +992,7 @@ defmodule Tensorflex do
   panda, panda, panda bear, coon bear, Ailuropoda melanoleuca` (Line 3691 in the
   file). Thus, we have correctly identified the animal in the image as a panda
   using Tensorflex.  
-"""
+  """
 
   def load_image_as_tensor(imagepath) do
     unless File.exists?(imagepath) do
@@ -1182,7 +1182,7 @@ defmodule Tensorflex do
 
   * Working with an RNN-LSTM example for sentiment analysis is covered
      [here](https://github.com/anshuman23/tensorflex/pull/25).  
-"""
+  """
 
   def run_session(%Graph{def: graphdef, name: _filepath}, %Tensor{datatype: _input_datatype, tensor: input_ref}, %Tensor{datatype: _output_datatype, tensor: output_ref}, input_opname, output_opname) do
     NIFs.run_session(graphdef, input_ref, output_ref, input_opname, output_opname)

--- a/lib/tensorflex.ex
+++ b/lib/tensorflex.ex
@@ -1,10 +1,10 @@
 defmodule Tensorflex do
   @moduledoc """
   A simple and fast library for running Tensorflow graph models in Elixir.
-Tensorflex is written around the [Tensorflow C
-API](https://www.tensorflow.org/install/install_c), and allows Elixir
-developers to leverage Machine Learning and Deep Learning solutions in their
-projects.
+  Tensorflex is written around the [Tensorflow C
+  API](https://www.tensorflow.org/install/install_c), and allows Elixir
+  developers to leverage Machine Learning and Deep Learning solutions in their
+  projects.
 
   __NOTE__:
 
@@ -24,7 +24,7 @@ projects.
     different tensor datatypes than the ones required by the graph can all lead to
     failure. While these are not easy errors to make, do ensure that you test your
     solution well before deployment.  
-"""
+  """
   
   alias Tensorflex.{NIFs, Graph, Tensor, Matrix}
 
@@ -41,7 +41,7 @@ projects.
   Returns a tuple `{:ok, %Graph}`. 
   
   `%Graph` is an internal Tensorflex struct which holds the name of the graph
-file and the binary definition data that is read in via the `.pb` file. 
+  file and the binary definition data that is read in via the `.pb` file. 
 
   ## Examples:
   
@@ -217,7 +217,7 @@ file and the binary definition data that is read in via the `.pb` file.
   ```
   """
 
-  def get_graph_ops(%Graph{def: ref, name: filepath}) do
+  def get_graph_ops(%Graph{def: ref, name: _filepath}) do
     NIFs.get_graph_ops(ref)
   end
 
@@ -343,7 +343,7 @@ file and the binary definition data that is read in via the `.pb` file.
   ```
   """
 
-  def matrix_pos(%Matrix{nrows: nrows, ncols: ncols, data: ref}, row, col) when row > 0 and col > 0 do
+  def matrix_pos(%Matrix{nrows: _nrows, ncols: _ncols, data: ref}, row, col) when row > 0 and col > 0 do
     NIFs.matrix_pos(ref, row, col)
   end
 
@@ -370,7 +370,7 @@ file and the binary definition data that is read in via the `.pb` file.
   ```
   """
 
-  def size_of_matrix(%Matrix{nrows: nrows, ncols: ncols, data: ref}) do
+  def size_of_matrix(%Matrix{nrows: nrows, ncols: ncols, data: _ref}) do
     {nrows, ncols}
   end
 
@@ -453,7 +453,7 @@ file and the binary definition data that is read in via the `.pb` file.
   ```
   """
 
-  def matrix_to_lists(%Matrix{nrows: nrows, ncols: ncols, data: ref}) do
+  def matrix_to_lists(%Matrix{nrows: _nrows, ncols: _ncols, data: ref}) do
     NIFs.matrix_to_lists(ref)
   end
 
@@ -495,7 +495,7 @@ file and the binary definition data that is read in via the `.pb` file.
   ```
   """
 
-  def float64_tensor(%Matrix{nrows: val_rows, ncols: val_cols, data: val_ref}, %Matrix{nrows: dim_rows, ncols: dim_cols, data: dim_ref}) do
+  def float64_tensor(%Matrix{nrows: _val_rows, ncols: _val_cols, data: val_ref}, %Matrix{nrows: _dim_rows, ncols: _dim_cols, data: dim_ref}) do
     {:ok, ref} = NIFs.float64_tensor(val_ref, dim_ref)
     {:ok, %Tensor{datatype: :tf_double, tensor: ref}} 
   end
@@ -575,7 +575,7 @@ file and the binary definition data that is read in via the `.pb` file.
   ```
   """
 
-  def float32_tensor(%Matrix{nrows: val_rows, ncols: val_cols, data: val_ref}, %Matrix{nrows: dim_rows, ncols: dim_cols, data: dim_ref}) do
+  def float32_tensor(%Matrix{nrows: _val_rows, ncols: _val_cols, data: val_ref}, %Matrix{nrows: _dim_rows, ncols: _dim_cols, data: dim_ref}) do
     {:ok, ref} = NIFs.float32_tensor(val_ref, dim_ref)
     {:ok, %Tensor{datatype: :tf_float, tensor: ref}} 
   end
@@ -659,7 +659,7 @@ file and the binary definition data that is read in via the `.pb` file.
   ```
   """
 
-  def int32_tensor(%Matrix{nrows: val_rows, ncols: val_cols, data: val_ref}, %Matrix{nrows: dim_rows, ncols: dim_cols, data: dim_ref}) do
+  def int32_tensor(%Matrix{nrows: _val_rows, ncols: _val_cols, data: val_ref}, %Matrix{nrows: _dim_rows, ncols: _dim_cols, data: dim_ref}) do
     {:ok, ref} = NIFs.int32_tensor(val_ref, dim_ref)
     {:ok, %Tensor{datatype: :tf_int32, tensor: ref}} 
   end
@@ -769,7 +769,7 @@ file and the binary definition data that is read in via the `.pb` file.
   ```
   """
 
-  def int32_tensor_alloc(%Matrix{nrows: dim_rows, ncols: dim_cols, data: dim_ref}) do
+  def int32_tensor_alloc(%Matrix{nrows: _dim_rows, ncols: _dim_cols, data: dim_ref}) do
     {:ok, ref} = NIFs.int32_tensor_alloc(dim_ref)
     {:ok, %Tensor{datatype: :tf_int32, tensor: ref}} 
   end
@@ -805,7 +805,7 @@ file and the binary definition data that is read in via the `.pb` file.
   ```
   """
   
-  def float32_tensor_alloc(%Matrix{nrows: dim_rows, ncols: dim_cols, data: dim_ref}) do
+  def float32_tensor_alloc(%Matrix{nrows: _dim_rows, ncols: _dim_cols, data: dim_ref}) do
     {:ok, ref} = NIFs.float32_tensor_alloc(dim_ref)
     {:ok, %Tensor{datatype: :tf_float, tensor: ref}} 
   end
@@ -841,7 +841,7 @@ file and the binary definition data that is read in via the `.pb` file.
   ```
   """
 
-  def float64_tensor_alloc(%Matrix{nrows: dim_rows, ncols: dim_cols, data: dim_ref}) do
+  def float64_tensor_alloc(%Matrix{nrows: _dim_rows, ncols: _dim_cols, data: dim_ref}) do
     {:ok, ref} = NIFs.float64_tensor_alloc(dim_ref)
     {:ok, %Tensor{datatype: :tf_double, tensor: ref}} 
   end
@@ -871,7 +871,7 @@ file and the binary definition data that is read in via the `.pb` file.
   ```
   """
 
-  def tensor_datatype(%Tensor{datatype: datatype, tensor: ref}) do
+  def tensor_datatype(%Tensor{datatype: datatype, tensor: _ref}) do
     {:ok, datatype}
   end
 
@@ -1184,7 +1184,7 @@ file and the binary definition data that is read in via the `.pb` file.
      [here](https://github.com/anshuman23/tensorflex/pull/25).  
 """
 
-  def run_session(%Graph{def: graphdef, name: filepath}, %Tensor{datatype: input_datatype, tensor: input_ref}, %Tensor{datatype: output_datatype, tensor: output_ref}, input_opname, output_opname) do
+  def run_session(%Graph{def: graphdef, name: _filepath}, %Tensor{datatype: _input_datatype, tensor: input_ref}, %Tensor{datatype: _output_datatype, tensor: output_ref}, input_opname, output_opname) do
     NIFs.run_session(graphdef, input_ref, output_ref, input_opname, output_opname)
   end
   

--- a/test/tensorflex_test.exs
+++ b/test/tensorflex_test.exs
@@ -138,8 +138,8 @@ defmodule TensorflexTest do
 
   describe "graph loading and reading functionalities" do
     test "graph loading check" do
-      {:ok, graph_toy} = Tensorflex.read_graph "./test/graphdef_toy.pb"
-      {:ok, graph_iris} = Tensorflex.read_graph "./test/graphdef_iris.pb"
+      {:ok, _graph_toy} = Tensorflex.read_graph "./test/graphdef_toy.pb"
+      {:ok, _graph_iris} = Tensorflex.read_graph "./test/graphdef_iris.pb"
     end
 
     test "get all graph ops" do
@@ -151,11 +151,11 @@ defmodule TensorflexTest do
 
     test "incorrect usage check" do
       assert_raise ArgumentError, fn ->
-	{:ok, graph} = Tensorflex.read_graph "Makefile"
+	{:ok, _graph} = Tensorflex.read_graph "Makefile"
       end
       
       assert_raise ArgumentError, fn ->
-	{:ok, graph} = Tensorflex.read_graph "Makefile.pb"
+	{:ok, _graph} = Tensorflex.read_graph "Makefile.pb"
       end
     end
   end
@@ -185,7 +185,7 @@ defmodule TensorflexTest do
 
     test "CSV-to-matrix function incorrect usage check" do
       assert_raise ArgumentError, fn ->
-	m = Tensorflex.load_csv_as_matrix("./test/sample1.csv", header: :no_header, delimiter: ",")
+	_m = Tensorflex.load_csv_as_matrix("./test/sample1.csv", header: :no_header, delimiter: ",")
       end
     end
   end


### PR DESCRIPTION
@josevalim fixed the indentation as you had asked.
Also ensured that the warnings do not appear anymore for unused variables in both:
- The tests
![tflex1](https://user-images.githubusercontent.com/19709056/43491993-8ef13bb2-9544-11e8-9d82-75c9655df6c3.png)

- During compilation
![tflex2](https://user-images.githubusercontent.com/19709056/43491997-92a55144-9544-11e8-8f00-cd33a0c337aa.png)